### PR TITLE
Find SPCM DLL in new install location

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,15 +94,17 @@ Windows 10+ (64-bit Intel).
 Python 3.10+ (64-bit).
 
 The Becker & Hickl [SPCM-DLL][bh-spcm-dll] (part of their [TCSPC
-Package][bh-tcspc-package] installer) must be installed on the system. The most
+Package][bh-tcspc-package] installer or [SPCM Data Acquisition
+Software][bh-spcm-package] installer) must be installed on the system. The most
 recent version is usually recommended; the theoretical minimum is version 4.0
 (Apr 2014; but versions below 5.1 have not been tested). Note that these are
 version numbers of SPCM-DLL, not of the TCSPC Package or the SPCM application.
 
 [bh-tcspc-package]: https://www.becker-hickl.com/products/tcspc-package/
+[bh-spcm-package]: https://www.becker-hickl.com/products/spcm-data-acquisition-software/
 
-The DLL is automatically found at its installed location; there is no need to
-copy it or set any environment variables.
+The DLL is automatically found at its installed location; there is usually no
+need to copy it or set any environment variables.
 
 ## License
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -54,8 +54,12 @@ Python 3.10+.
 
 Becker & Hickl TCSPC Package with SPCM-DLL 5.2.0 (Sep 2023, TCSPC Package 7.0)
 or later (note that a more recent version is required than at run time). SPCM
-DLL 5.1.0 (Dec 2022) is the theoretical minimum requirement, but its header
-file `Spcm_def.h` may need to have trailing whitespace removed to compile.
+DLL 5.1.0 (Dec 2022) is the theoretical minimum requirement for building, but
+its header file `Spcm_def.h` may need to have trailing whitespace removed in
+order to compile.
+
+Becker & Hickl SPCM Data Acquisition Software 9.91.0 (SPCM DLL 5.4.0) or later
+should also work instead of the larger TCSPC Package.
 
 ### Pre-commit hook
 

--- a/meson.build
+++ b/meson.build
@@ -28,24 +28,35 @@ python = import('python').find_installation(pure: false)
 
 spcm64_found = false
 
-spcm64_dir = get_option('spcm_dll_dir')
-if fs.is_dir(spcm64_dir)
-    spcm64_inc = include_directories(fs.relative_to(spcm64_dir, '.'))
-    spcm64_lib = cc.find_library(
-        'spcm64',
-        dirs: [spcm64_dir / 'LIB/MSVC64'],
-        has_headers: ['Spcm_def.h'],
-        header_include_directories: spcm64_inc,
-        required: false,
-    )
-    if spcm64_lib.found()
-        spcm64_dep = declare_dependency(
-            dependencies: [spcm64_lib],
-            include_directories: [spcm64_inc],
-        )
-        spcm64_found = true
-    endif
+spcm64_dir_candidates = [
+    get_option('spcm_dll_dir'),
+]
+if spcm64_dir_candidates.get(0) == ''
+    spcm64_dir_candidates = [
+        'C:/Program Files/Becker-Hickl/SPCM/DLL',  # Since 5.4.0
+        'C:/Program Files (x86)/BH/SPCM/DLL',      # Up to 5.3.0
+    ]
 endif
+foreach spcm64_dir : spcm64_dir_candidates
+    if fs.is_dir(spcm64_dir)
+        spcm64_inc = include_directories(fs.relative_to(spcm64_dir, '.'))
+        spcm64_lib = cc.find_library(
+            'spcm64',
+            dirs: [spcm64_dir / 'LIB/MSVC64'],
+            has_headers: ['Spcm_def.h'],
+            header_include_directories: spcm64_inc,
+            required: false,
+        )
+        if spcm64_lib.found()
+            spcm64_dep = declare_dependency(
+                dependencies: [spcm64_lib],
+                include_directories: [spcm64_inc],
+            )
+            spcm64_found = true
+            break
+        endif
+    endif
+endforeach
 
 if not spcm64_found # Fall back to wrap (used for CI)
     spcm64_dep = dependency('spcm-dll')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -4,6 +4,5 @@
 
 option('spcm_dll_dir',
     type: 'string',
-    value: 'C:/Program Files (x86)/BH/SPCM/DLL',
-    description: 'Path to the SPCM DLL installation',
+    description: 'Path to the SPCM DLL installation (try default locations if empty)',
 )

--- a/subprojects/packagefiles/spcm-dll/meson.build
+++ b/subprojects/packagefiles/spcm-dll/meson.build
@@ -4,6 +4,10 @@
 
 project('spcm-dll', 'c')
 
+# This build file simply wraps the headers and import library (.lib) binary as
+# a dependency, as suggested in
+# https://mesonbuild.com/Shipping-prebuilt-binaries-as-wraps.html
+
 if host_machine.system() != 'windows' or host_machine.cpu_family() != 'x86_64'
     error('Only supports Windows x64')
 endif

--- a/subprojects/spcm-dll.wrap
+++ b/subprojects/spcm-dll.wrap
@@ -2,9 +2,13 @@
 # Copyright 2024-2025 Board of Regents of the University of Wisconsin System
 # SPDX-License-Identifier: MIT
 
+# This is for use by automated builds on GitHub; it won't work unless you have
+# access to the private spcm-dll repository. Install SPCM DLL on your system
+# instead.
+
 [wrap-git]
 url = https://github.com/marktsuchida/spcm-dll.git
-revision = v5.3.0
+revision = v5.4.0
 depth = 1
 patch_directory = spcm-dll
 


### PR DESCRIPTION
BH now provides an SPCM-only installer (9.91.0) that installs in a new location.